### PR TITLE
Fix: Adapt to python default env name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,11 @@
 # defaults templates for custom_facts
 custom_facts__templates:
   - groups
-
-# defaults scripts for custom_facts
-custom_facts__scripts:
   - active_users
   - sudo_users
+
+# defaults scripts for custom_facts
+custom_facts__scripts: []
 
 # Additional facts
 custom_facts__additional_templates: []

--- a/templates/active_users.fact
+++ b/templates/active_users.fact
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python{% if ansible_distribution_major_version|int >= 10 %}3{% endif %}
 
 import sys, json, pwd
 

--- a/templates/sudo_users.fact
+++ b/templates/sudo_users.fact
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python{% if ansible_distribution_major_version|int >= 10 %}3{% endif %}
 
 import sys, json, grp
 


### PR DESCRIPTION
On bullseye, default name for python is python3. /usr/bin/env adapted